### PR TITLE
use github for image hosting

### DIFF
--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -13,10 +13,12 @@ defineEmits(["addToCart"])
 
 // data
 const count = ref(0);
+const imgRoot =
+  'https://raw.githubusercontent.com/vueschool/pinia-the-enjoyable-vue-store/main/public/images/';
 </script>
 <template>
   <li class="card">
-    <img :src="`/images/${product.image}`" class="mb-3" width="300" />
+    <img :src="`${imgRoot}/${product.image}`" class="mb-3" width="300" />
     <div>
       {{ product.name }} - <span class="text-green-500">${{product.price}}</span>
       <div class="text-center m-4">


### PR DESCRIPTION
This plays nicer with free versions of stackblitz, which will not allow blob files like images to be forked.

To reproduce:
1. Start with: https://stackblitz.com/fork/github/vueschool/pinia-the-enjoyable-vue-store/tree/9b595f301c43c901dbdb5cc05e90f689f47905b3
2. Click fork
3. Witness your fork have zero byte image files

![Screenshot 2022-07-15 12 29 58](https://user-images.githubusercontent.com/876076/179277300-f1107a53-b023-4211-bea1-352fa6b13a17.png)

Alternatively:
- We could use SVG's
- We could use base64 encoded images in a json
- We could load the images from an NPM package